### PR TITLE
REAL_FINAL_PROJECT

### DIFF
--- a/self_drive.cpp
+++ b/self_drive.cpp
@@ -31,39 +31,40 @@ public:
   void subscribe_scan(const sensor_msgs::msg::LaserScan::SharedPtr scan)
   {
     geometry_msgs::msg::Twist vel;
+    double front_distance = scan->ranges[0];
+    double diagonal_left_distance1 = scan->ranges[45];
+    double diagonal_left_distance2 = scan->ranges[135];
+    double left_vertical= scan->ranges[90];
     
-      if(scan->ranges[0] <= 0.25)
-      {      
-        vel.linear.x = 0.0;
-        vel.angular.z = -1.0;    
-      }
-      else
+       
+    if (front_distance <= 0.35)
+    {
+      vel.linear.x = 0.0;
+      vel.angular.z = -1.0;
+    }
+    else
+    {
+      vel.linear.x = 0.15;
+
+      if (left_vertical <= 0.2)
       {
         vel.linear.x = 0.15;
         vel.angular.z = 0.0;
       }
-
-      if (scan->ranges[120] <= 0.2 )
-      {
-        vel.linear.x = 0.0;
-        vel.angular.z = 1.0;
-      }     
-      else if (scan->ranges[60]<=0.2)
-      {
-        vel.linear.x = 0.0;
-        vel.angular.z = -1.0;
-      }
-      else if (scan->ranges[70]>0.6 && scan->ranges[90] <= 0.4)
+      else if (diagonal_left_distance1 > diagonal_left_distance2)
       {
         vel.linear.x = 0.1;
         vel.angular.z = 1.0;
       }
-      else
+      else if (diagonal_left_distance2 > diagonal_left_distance1)
       {
-          vel.linear.x = 0.15;
+        vel.linear.x = 0.1;
+        vel.angular.z = -1.0;
       }
       
       
+      
+    }
   
    std::cout <<"test09" <<std::endl;
     RCLCPP_INFO(rclcpp::get_logger("self_drive"),

--- a/self_drive_final.cpp
+++ b/self_drive_final.cpp
@@ -1,0 +1,86 @@
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+using namespace std::chrono_literals;
+
+class SelfDrive : public rclcpp::Node
+{
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pose_pub_;
+  int step_;
+  
+public:
+  SelfDrive() : rclcpp::Node("self_drive"), step_(0)
+  {
+    auto lidar_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    lidar_qos_profile.reliability(rclcpp::ReliabilityPolicy::BestEffort);
+    auto callback = std::bind(&SelfDrive::subscribe_scan, this, std::placeholders::_1);
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile,
+                                                                       callback);
+    auto vel_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    pose_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", vel_qos_profile);
+  }
+
+  void subscribe_scan(const sensor_msgs::msg::LaserScan::SharedPtr scan)
+  {
+    geometry_msgs::msg::Twist vel;
+    double front_distance = scan->ranges[0];
+    double diagonal_left_distance1 = scan->ranges[45];
+    double diagonal_left_distance2 = scan->ranges[135];
+    double left_vertical= scan->ranges[90];
+    
+       
+    if (front_distance <= 0.35)
+    {
+      vel.linear.x = 0.0;
+      vel.angular.z = -1.0;
+    }
+    else
+    {
+      vel.linear.x = 0.15;
+
+      if (left_vertical <= 0.2)
+      {
+        vel.linear.x = 0.15;
+        vel.angular.z = 0.0;
+      }
+      else if (diagonal_left_distance1 > diagonal_left_distance2)
+      {
+        vel.linear.x = 0.1;
+        vel.angular.z = 1.0;
+      }
+      else if (diagonal_left_distance2 > diagonal_left_distance1)
+      {
+        vel.linear.x = 0.1;
+        vel.angular.z = -1.0;
+      }
+      
+      
+      
+    }
+  
+   std::cout <<"test09" <<std::endl;
+    RCLCPP_INFO(rclcpp::get_logger("self_drive"),
+                "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f", step_, scan->ranges[0],
+                vel.linear.x, vel.angular.z);
+    pose_pub_->publish(vel);
+    step_++;
+  }
+  
+};
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<SelfDrive>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
먼저 기본적인 주행이 되기 위해서 장애물을 피하는 코드로 전방에 있는 값이 25cm이하면 멈추는 코드에서부터 출발하였다.
레벨 2인 벽 따라가기를 수행시키기 위해서 코드를 작성하기 위해 가장 먼저 생각한 것은
주행하다가 벽을 만나게 되면 좌측이나 우측 둘 중에 하나를 우리가 선택하여 벽에 부딪히지 않으며, 벽을 따라갈 수 있도록
25cm이하면 멈추는 코드에서 회전하는 코드로 맞춰 넣었다. 
변수가 발생하게 되는데, 라이다 감지 범위를 전방에만 두어서 양 대각선측 혹은 양 뒷 대각선측 등등 전방을 제외한 다른 부분이
벽에 부딪히는 변수가 발생하게 되어서 그 변수를 줄이고자 대각선 라이다 감지 범위를 만들었다.
대각선 라이다 감지 범위에 들어왔을 때 너무 가까우면 멀어지고 너무 멀어지면 가까워지도록 코드를 짜고 싶었으나, 
라이다의 오차 범위, 감지 범위의 한계 등등으로 인해 생각한대로 짠 코드가 그대로 로봇에 실행되지 않았다.
벽의 바깥쪽면 벽을 쭉 따라 돌 수 있도록 하기 위해서 각 두개의 각과 벽 사이의 거리의 차를 이용하여, 멀어지면 돌아오고 가까워지면 멀어지도록 설계하려고 하였으나, 생각대로 되지않은 것들이 많아 결국 실패했다.
